### PR TITLE
Potential fix for code scanning alert no. 2: URL redirection from remote source

### DIFF
--- a/app/money/views/journals.py
+++ b/app/money/views/journals.py
@@ -8,6 +8,7 @@ from django.db.models import Count
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext_lazy as _
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from ..forms import JournalForm
 from ..models import Journal, Tag, Template
@@ -55,7 +56,10 @@ def new(request):
         else:
             messages.error(request, _('Failed to create journal'))
 
-        return redirect(request.GET.get('next', 'money:journals'))
+        next_url = request.GET.get('next', 'money:journals')
+        if not url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+            next_url = 'money:journals'
+        return redirect(next_url)
 
     v_template = request.GET.get('template')
     v_base = request.GET.get('base')


### PR DESCRIPTION
Potential fix for [https://github.com/taqueci/nomoney/security/code-scanning/2](https://github.com/taqueci/nomoney/security/code-scanning/2)

The best way to fix this problem is to validate the provided `next` parameter before using it for redirection. In Django, the idiomatic way to do this is to use `django.utils.http.url_has_allowed_host_and_scheme`, which checks if the URL is a safe host and optionally restricts to internal locations (by default not allowing external redirects). In this code, before passing the `next` parameter to `redirect`, we should first check that it is a safe redirect target. If it is not, we should ignore it and redirect to a fixed internal view (`money:journals`). 

Specifically:
- In file `app/money/views/journals.py`, modify line 58 so that before redirecting to `next`, you check with `url_has_allowed_host_and_scheme`. Only use `next` if it passes the check; otherwise, redirect to `'money:journals'`.
- You will need to import `url_has_allowed_host_and_scheme` from `django.utils.http`.
- Use `request.get_host()` as the allowed host.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
