### PR TITLE
Potential fix for code scanning alert no. 5: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/app/system/models.py
+++ b/app/system/models.py
@@ -51,9 +51,9 @@ class User(UserLanguageSupportMixin, UserTimeZoneSupportMixin, AbstractUser):
     def file_path(self, filename):
         """File path for user image."""
 
-        md5 = hashlib.md5(f'{self.username}z'.encode()).hexdigest()
+        digest = hashlib.sha256(f'{self.username}z'.encode()).hexdigest()
 
-        return f'{IMAGE_DIR_USER}/{md5}/{int(time.time())}-{filename}'
+        return f'{IMAGE_DIR_USER}/{digest}/{int(time.time())}-{filename}'
 
     is_verified = models.BooleanField(
         _('verified'),


### PR DESCRIPTION
Potential fix for [https://github.com/taqueci/nomoney/security/code-scanning/5](https://github.com/taqueci/nomoney/security/code-scanning/5)

Use a strong modern hash function for the username-based path segment in `User.file_path`, replacing MD5 with SHA-256 (or SHA-3). This keeps functionality the same (deterministic, hex string directory segment) while removing the weak algorithm.

Best single fix in `app/system/models.py`:
- In `User.file_path` (lines 54–56 region), replace:
  - `md5 = hashlib.md5(...).hexdigest()`
  - return path using `md5`
- With:
  - `digest = hashlib.sha256(...).hexdigest()`
  - return path using `digest`

No new dependency is required; `hashlib` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
